### PR TITLE
chore: uncomment SnowflakeTargetSchemaUpdates test

### DIFF
--- a/tests/test_impl.py
+++ b/tests/test_impl.py
@@ -251,8 +251,7 @@ target_tests = TestSuite(
         SnowflakeTargetRecordBeforeSchemaTest,
         SnowflakeTargetRecordMissingKeyProperty,
         SnowflakeTargetSchemaNoProperties,
-        # TODO: bug https://github.com/MeltanoLabs/target-snowflake/issues/43
-        # SnowflakeTargetSchemaUpdates,
+        SnowflakeTargetSchemaUpdates,
         TargetSpecialCharsInAttributes,  # Implicitly asserts that special chars are handled
     ],
 )


### PR DESCRIPTION
Closes https://github.com/MeltanoLabs/target-snowflake/issues/43

It turns out that this test had been fixed by other changes. I suspect it was part of https://github.com/MeltanoLabs/target-snowflake/pull/39. Previously I had implemented a way to cache table properties but I suspect that the cache was not being invalidated when the schema updated so it was attempting to recreate an existing column since it didnt find it in the cache.