### PR TITLE
fix: camelcase test

### DIFF
--- a/target_snowflake/sinks.py
+++ b/target_snowflake/sinks.py
@@ -143,7 +143,7 @@ class SnowflakeSink(SQLSink):
                 # merge into destination table
                 self.connector.merge_from_stage(
                     full_table_name=full_table_name,
-                    schema=self.conform_schema(self.schema),
+                    schema=self.schema,
                     sync_id=sync_id,
                     file_format=file_format,
                     key_properties=self.key_properties,
@@ -152,7 +152,7 @@ class SnowflakeSink(SQLSink):
             else:
                 self.connector.copy_from_stage(
                     full_table_name=full_table_name,
-                    schema=self.conform_schema(self.schema),
+                    schema=self.schema,
                     sync_id=sync_id,
                     file_format=file_format,
                 )

--- a/tests/test_impl.py
+++ b/tests/test_impl.py
@@ -237,8 +237,7 @@ target_tests = TestSuite(
     tests=[
         SnowflakeTargetArrayData,
         SnowflakeTargetCamelcaseComplexSchema,
-        # TODO: bug https://github.com/MeltanoLabs/target-snowflake/issues/40
-        # SnowflakeTargetCamelcaseTest,
+        SnowflakeTargetCamelcaseTest,
         TargetCliPrintsTest,
         # TODO: bug https://github.com/MeltanoLabs/target-snowflake/issues/41
         # SnowflakeTargetDuplicateRecords,


### PR DESCRIPTION
Closes https://github.com/MeltanoLabs/target-snowflake/issues/40

The merge_from_stage and copy_from_stage accept a schema argument that it uses to build a query that selects from the raw json files in the stage using the json keys. Since the staging data is raw, we needed to pass in the raw unconformed schema instead of the conformed schema. The conformed schema converted the camelcase `Id` column to lower case `id`, so the query it built was trying to select a key in the json file that didnt exist. The query has lowercase and the file has camelcase.
