### PR TITLE
fix: duplicate record test

### DIFF
--- a/target_snowflake/connector.py
+++ b/target_snowflake/connector.py
@@ -195,13 +195,13 @@ class SnowflakeConnector(SQLConnector):
         not_matched_insert_values = ", ".join(
             [f's."{col}"' for col in upper_properties]
         )
-        dedupe_cols = ", ".join([f"$1:{key_prop}" for key_prop in key_properties])
-        dedupe = f"QUALIFY ROW_NUMBER() OVER (PARTITION BY {dedupe_cols} ORDER BY SEQ8() DESC) = 1"
+        dedup_cols = ", ".join([f"$1:{key_prop}" for key_prop in key_properties])
+        dedup = f"QUALIFY ROW_NUMBER() OVER (PARTITION BY {dedup_cols} ORDER BY SEQ8() DESC) = 1"
         return (
             text(
                 f"merge into {full_table_name} d using "
                 + f"(select {', '.join(column_selections)} from '@~/target-snowflake/{sync_id}'"
-                + f"(file_format => {file_format}) {dedupe}) s "
+                + f"(file_format => {file_format}) {dedup}) s "
                 + f"on {join_expr} "
                 + f"when matched then update set {matched_clause} "
                 + f"when not matched then insert ({not_matched_insert_cols}) "

--- a/target_snowflake/connector.py
+++ b/target_snowflake/connector.py
@@ -195,11 +195,13 @@ class SnowflakeConnector(SQLConnector):
         not_matched_insert_values = ", ".join(
             [f's."{col}"' for col in upper_properties]
         )
+        dedupe_cols = ", ".join([f"$1:{key_prop}" for key_prop in key_properties])
+        dedupe = f"QUALIFY ROW_NUMBER() OVER (PARTITION BY {dedupe_cols} ORDER BY SEQ8() DESC) = 1"
         return (
             text(
                 f"merge into {full_table_name} d using "
                 + f"(select {', '.join(column_selections)} from '@~/target-snowflake/{sync_id}'"
-                + f"(file_format => {file_format})) s "
+                + f"(file_format => {file_format}) {dedupe}) s "
                 + f"on {join_expr} "
                 + f"when matched then update set {matched_clause} "
                 + f"when not matched then insert ({not_matched_insert_cols}) "

--- a/tests/test_impl.py
+++ b/tests/test_impl.py
@@ -239,8 +239,7 @@ target_tests = TestSuite(
         SnowflakeTargetCamelcaseComplexSchema,
         SnowflakeTargetCamelcaseTest,
         TargetCliPrintsTest,
-        # TODO: bug https://github.com/MeltanoLabs/target-snowflake/issues/41
-        # SnowflakeTargetDuplicateRecords,
+        SnowflakeTargetDuplicateRecords,
         SnowflakeTargetEncodedStringData,
         SnowflakeTargetInvalidSchemaTest,
         # Not available in the SDK yet


### PR DESCRIPTION
Closes https://github.com/MeltanoLabs/target-snowflake/issues/41

The challenge is that we're using a merge statement which is successfully deduplicating against what already exists in the target table but within the batch of records in the stage there are also dupes. The test was failing because no data existed in the destination table so we weren't updating any records, only inserting, but within our staging file we had multiple primary keys ID 1 and 2 so they all get inserting and the result is duplicates in the destination table.

The way I fixed it in this PR is by adding a qualify row_num = 1 to deduplicate within our staging file select query. It uses the SEQ8 function, which I've never used before, to order the records based on their place in the file i.e. the bottom of the table takes precedence over the top. I looks to work as expected but it feels a little sketchy, I wonder if unsorted streams would have issues where the wrong record gets selected. Ideally the user would tell us a sort by column to know how to take the latest.