### PR TITLE
fix: add schema updates with no key properties

### DIFF
--- a/tests/target_test_streams/schema_updates_no_key_props.singer
+++ b/tests/target_test_streams/schema_updates_no_key_props.singer
@@ -1,0 +1,11 @@
+{"type": "SCHEMA", "stream": "test_schema_updates", "key_properties": [], "schema": {"type": "object", "properties": {"id": {"type": "integer"}, "a1": {"type": "number"}, "a2": {"type": "string"}}}}
+{"type": "RECORD", "stream": "test_schema_updates", "record": {"id": 1, "a1": 101, "a2": "string1"}}
+{"type": "SCHEMA", "stream": "test_schema_updates", "key_properties": [], "schema": {"type": "object", "properties": {"id": {"type": "integer"}, "a1": {"type": "number"}, "a2": {"type": "string"}, "a3": {"type": "boolean"}}}}
+{"type": "RECORD", "stream": "test_schema_updates", "record": {"id": 2, "a1": 102, "a2": "string2", "a3": true}}
+{"type": "SCHEMA", "stream": "test_schema_updates", "key_properties": [], "schema": {"type": "object", "properties": {"id": {"type": "integer"}, "a1": {"type": "number"}, "a2": {"type": "string"}, "a3": {"type": "boolean"}, "a4": {"type": "object", "properties": {"id": {"type": "integer"}, "value": {"type": "integer"}}}, "a5": {"type": "array", "items": {"type": "string"}}}}}
+{"type": "RECORD", "stream": "test_schema_updates", "record": {"id": 3, "a1": 103, "a2": "string3", "a3": false, "a4": {"id": 1, "value": 1}, "a5": [ "banana", "apple" ]}}
+{"type": "RECORD", "stream": "test_schema_updates", "record": {"id": 4, "a1": 104, "a2": "string4", "a3": true, "a4": {"id": 2, "value": 22}, "a5": [ "orange", "pear" ]}}
+{"type": "SCHEMA", "stream": "test_schema_updates", "key_properties": [], "schema": {"type": "object", "properties": {"id": {"type": "integer"}, "a1": {"type": "number"}, "a2": {"type": "string"}, "a3": {"type": "boolean"}, "a4": {"type": "object", "properties": {"id": {"type": "integer"}, "value": {"type": "integer"}}}, "a5": {"type": "array", "items": {"type": "string"}}, "a6": {"type": "integer"}}}}
+{"type": "RECORD", "stream": "test_schema_updates", "record": {"id": 5, "a1": 105, "a2": "string5", "a3": false, "a4": {"id": 3, "value": 33}, "a5": [ "apple" ], "a6": 985}}
+{"type": "RECORD", "stream": "test_schema_updates", "record": {"id": 6, "a1": 106, "a2": "string6", "a3": true, "a4": {"id": 4, "value": 444}, "a5": [ "banana", "orange" ], "a6": 341}}
+{"type": "STATE", "value": {"test_schema_updates": 6}}

--- a/tests/test_impl.py
+++ b/tests/test_impl.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 import snowflake.sqlalchemy.custom_types as sct
 import sqlalchemy
@@ -204,7 +206,7 @@ class SnowflakeTargetSchemaNoProperties(TargetSchemaNoProperties):
 class SnowflakeTargetSchemaUpdates(TargetSchemaUpdates):
     def validate(self) -> None:
         connector = self.target.default_sink_class.connector_class(self.target.config)
-        table = f"{self.target.config['database']}.{self.target.config['default_target_schema']}.test_schema_updates".upper()
+        table = f"{self.target.config['database']}.{self.target.config['default_target_schema']}.test_{self.name}".upper()
         result = connector.connection.execute(
             f"select * from {table}",
         )
@@ -231,6 +233,14 @@ class SnowflakeTargetSchemaUpdates(TargetSchemaUpdates):
             assert column.name in expected_types
             isinstance(column.type, expected_types[column.name])
 
+class SnowflakeTargetSchemaUpdatesNoKeyProps(SnowflakeTargetSchemaUpdates):
+    name = "schema_updates_no_key_props"
+
+    @property
+    def singer_filepath(self) -> Path:
+        current_dir = Path(__file__).resolve().parent
+        return current_dir / "target_test_streams" / f"{self.name}.singer"
+
 
 target_tests = TestSuite(
     kind="target",
@@ -251,6 +261,7 @@ target_tests = TestSuite(
         SnowflakeTargetRecordMissingKeyProperty,
         SnowflakeTargetSchemaNoProperties,
         SnowflakeTargetSchemaUpdates,
+        SnowflakeTargetSchemaUpdatesNoKeyProps,
         TargetSpecialCharsInAttributes,  # Implicitly asserts that special chars are handled
     ],
 )


### PR DESCRIPTION
As part of https://github.com/MeltanoLabs/target-snowflake/pull/51 I wanted to add a test to assert schema changes when reserved words were used and no key properties were present so the COPY logic would get invoked. It failed and I realized that it would have been failing before my changes in that PR.

This PR adds the test case so we can figure out how to fix it. The problem I saw was that the file in the internal stage matched the initial schema record but by the time it was being loaded into the table the second schema message had already altered the table to the new schema. Ultimately leading to an error related to a mismatch in columns in the table vs stage file columns.