### PR TITLE
fix: handle precision from multipleOf number types

### DIFF
--- a/target_snowflake/connector.py
+++ b/target_snowflake/connector.py
@@ -14,6 +14,8 @@ from sqlalchemy.sql import text
 from target_snowflake.snowflake_types import NUMBER, TIMESTAMP_NTZ, VARIANT
 
 SNOWFLAKE_MAX_STRING_LENGTH = 16777216
+SNOWFLAKE_MAX_NUMBER_PRECISION = 38
+SNOWFLAKE_MAX_NUMBER_SCALE = 0
 
 class TypeMap:
     def __init__(self, operator, map_value, match_value=None):
@@ -93,7 +95,7 @@ class SnowflakeConnector(SQLConnector):
         if isinstance(sql_type, sct.TIMESTAMP_NTZ):
             return TIMESTAMP_NTZ
         elif isinstance(sql_type, sct.NUMBER):
-            return NUMBER
+            return NUMBER(precision=sql_type.precision, scale=sql_type.scale)
         elif isinstance(sql_type, sct.VARIANT):
             return VARIANT
         else:
@@ -213,6 +215,28 @@ class SnowflakeConnector(SQLConnector):
         return jsonschema_type
 
     @staticmethod
+    def _get_numeric_precision(jsonschema_type):
+        return SNOWFLAKE_MAX_NUMBER_PRECISION
+
+    @staticmethod
+    def _get_numeric_scale(jsonschema_type):
+        precision = SNOWFLAKE_MAX_NUMBER_SCALE
+        if jsonschema_type.get("exclusiveMinimum"):
+            if str(jsonschema_type[attrib])[-1] == 1:
+                return len(str(jsonschema_type[attrib]).split(".")[1]) - 1
+            else:
+                return len(str(jsonschema_type[attrib]).split(".")[1])
+        attribs_to_check = [
+            "multipleOf",
+            "min",
+            "max",
+        ]
+        for attrib in attribs_to_check:
+            if jsonschema_type.get(attrib):
+                precision = max(precision, len(str(jsonschema_type[attrib]).split(".")[1]))
+        return precision
+
+    @staticmethod
     def to_sql_type(jsonschema_type: dict) -> sqlalchemy.types.TypeEngine:
         """Return a JSON Schema representation of the provided type.
 
@@ -230,6 +254,8 @@ class SnowflakeConnector(SQLConnector):
         # snowflake max and default varchar length
         # https://docs.snowflake.com/en/sql-reference/intro-summary-data-types.html
         maxlength = jsonschema_type.get("maxLength", SNOWFLAKE_MAX_STRING_LENGTH)
+        num_precision = SnowflakeConnector._get_numeric_precision(jsonschema_type)
+        num_scale = SnowflakeConnector._get_numeric_scale(jsonschema_type)
         # define type maps
         string_submaps = [
             TypeMap(eq, TIMESTAMP_NTZ(), "date-time"),
@@ -241,6 +267,7 @@ class SnowflakeConnector(SQLConnector):
             TypeMap(th._jsonschema_type_check, NUMBER(), ("integer",)),
             TypeMap(th._jsonschema_type_check, VARIANT(), ("object",)),
             TypeMap(th._jsonschema_type_check, VARIANT(), ("array",)),
+            TypeMap(th._jsonschema_type_check, NUMBER(precision=num_precision, scale=num_scale), ("number",)),
         ]
         # apply type maps
         if th._jsonschema_type_check(jsonschema_type, ("string",)):

--- a/tests/core.py
+++ b/tests/core.py
@@ -431,10 +431,6 @@ class SnowflakeTargetTypeEdgeCasesTest(TargetFileTestTemplate):
     def validate(self) -> None:
         connector = self.target.default_sink_class.connector_class(self.target.config)
         table = f"{self.target.config['database']}.{self.target.config['default_target_schema']}.{self.name}".upper()
-        result = connector.connection.execute(
-            f"select * from {table} order by 1",
-        )
-        test = connector.get_table_columns(table)
         table_schema = connector.get_table(table)
         expected_types = {
             "id": sct.NUMBER,

--- a/tests/target_test_streams/type_edge_cases.singer
+++ b/tests/target_test_streams/type_edge_cases.singer
@@ -1,2 +1,2 @@
-{"type": "SCHEMA", "stream": "type_edge_cases", "key_properties": ["id"], "schema": {"required": ["id"], "type": "object", "properties": {"id": {"type": "integer"}, "col_max_length_str": {"maxLength": 4294967295, "type": [ "null", "string" ] }}}}
-{"type": "RECORD", "stream": "type_edge_cases", "record": {"id": 1, "col_max_length_str": "foo"}}
+{"type": "SCHEMA", "stream": "type_edge_cases", "key_properties": ["id"], "schema": {"required": ["id"], "type": "object", "properties": {"id": {"type": "integer"}, "col_max_length_str": {"maxLength": 4294967295, "type": [ "null", "string" ] }, "col_multiple_of": {"multipleOf": 0.0001, "type": [ "null", "number" ] }}}}
+{"type": "RECORD", "stream": "type_edge_cases", "record": {"id": 1, "col_max_length_str": "foo", "col_multiple_of": 123.456}}


### PR DESCRIPTION
Closes https://github.com/MeltanoLabs/target-snowflake/issues/77

- Adds test to assert multipleOf precision is extracted and used for column types
- Add fix to support it and make test pass
- I had to also parse it in `_convert_type`because the connector `get_table` method was used in the test and the precision wasnt being pulled back in when queried. The table was created with the right precision but when getting the column metadata it didnt include precision so it was hard to assert and I wonder if it would fail to diff properly and attempt to alter column types when theyre already correct. So I had to fix that part too.

cc @jpuris 