### PR TITLE
feat: Output record count metric from batch files insert

### DIFF
--- a/target_snowflake/connector.py
+++ b/target_snowflake/connector.py
@@ -553,7 +553,8 @@ class SnowflakeConnector(SQLConnector):
                 key_properties=key_properties,
             )
             self.logger.debug("Merging with SQL: %s", merge_statement)
-            conn.execute(merge_statement, **kwargs)
+            result = conn.execute(merge_statement, **kwargs)
+            return result.rowcount
 
     def copy_from_stage(
         self,
@@ -578,7 +579,8 @@ class SnowflakeConnector(SQLConnector):
                 file_format=file_format,
             )
             self.logger.debug("Copying with SQL: %s", copy_statement)
-            conn.execute(copy_statement, **kwargs)
+            result = conn.execute(copy_statement, **kwargs)
+            return result.rowcount
 
     def drop_file_format(self, file_format: str) -> None:
         """Drop a file format in the schema.

--- a/target_snowflake/sinks.py
+++ b/target_snowflake/sinks.py
@@ -190,7 +190,7 @@ class SnowflakeSink(SQLSink[SnowflakeConnector]):
 
             if self.key_properties:
                 # merge into destination table
-                self.connector.merge_from_stage(
+                record_count = self.connector.merge_from_stage(
                     full_table_name=full_table_name,
                     schema=self.schema,
                     sync_id=sync_id,
@@ -199,12 +199,15 @@ class SnowflakeSink(SQLSink[SnowflakeConnector]):
                 )
 
             else:
-                self.connector.copy_from_stage(
+                record_count = self.connector.copy_from_stage(
                     full_table_name=full_table_name,
                     schema=self.schema,
                     sync_id=sync_id,
                     file_format=file_format,
                 )
+
+            with self.record_counter_metric as counter:
+                counter.increment(record_count)
 
         finally:
             self.logger.debug("Cleaning up after batch processing")


### PR DESCRIPTION
Bit of an opinionated change since it might be conflating batches/records, but it has been helpful for us to know how many rows (records) were created/updated from batch processing.