### PR TITLE
ci: Add timeout of 5 minutes to test job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ concurrency:
 jobs:
   pytest:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       SINGER_SDK_LOG_CONFIG: ./target_snowflake_logging.yaml


### PR DESCRIPTION
The tests usually run for less than 2 minutes, so 5 minutes should be enough to then decide to cancel them.
