### PR TITLE
fix: Fail early if `private_key_path` doesn't exist

### DIFF
--- a/target_snowflake/connector.py
+++ b/target_snowflake/connector.py
@@ -120,8 +120,13 @@ class SnowflakeConnector(SQLConnector):
         phrase = self.config.get("private_key_passphrase")
         encoded_passphrase = phrase.encode() if phrase else None
         if "private_key_path" in self.config:
-            with Path(self.config["private_key_path"]).open("rb") as key:
-                key_content = key.read()
+            self.logger.debug("Reading private key from file: %s", self.config["private_key_path"])
+            key_path = Path(self.config["private_key_path"])
+            if not key_path.is_file():
+                error_message = f"Private key file not found: {key_path}"
+                raise FileNotFoundError(error_message)
+            with key_path.open("rb") as key_file:
+                key_content = key_file.read()
         else:
             key_content = self.config["private_key"].encode()
 


### PR DESCRIPTION

This pull request includes an important update to the `get_private_key` method in the `target_snowflake/connector.py` file. The changes enhance logging and error handling when reading the private key from a file.

Enhancements to logging and error handling:

* Added a debug log statement to indicate when the private key is being read from a file.
* Introduced a check to verify if the private key file exists before attempting to read it, raising a `FileNotFoundError` with a descriptive error message if the file is not found.