### PR TITLE
chore: Update Dependabot configuration to remove runtime dependencies grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,10 +16,6 @@ updates:
     groups:
       development-dependencies:
         dependency-type: development
-      runtime-dependencies:
-        dependency-type: production
-        update-types:
-          - "patch"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
Removed runtime-dependencies group from Dependabot configuration.