### PR TITLE
fix: Unrecognised UUID type error when reflecting Snowflake columns

### DIFF
--- a/target_snowflake/connector.py
+++ b/target_snowflake/connector.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import binascii
 import urllib.parse
+import uuid
 from contextlib import contextmanager
 from enum import Enum
 from functools import cached_property
@@ -294,6 +295,10 @@ class SnowflakeConnector(SQLConnector):
             connect_args=self.get_connect_args(),
             echo=False,
         )
+
+        engine.dialect.ischema_names["UUID"] = sqlalchemy.types.UUID
+        engine.dialect.colspecs[uuid.UUID] = sqlalchemy.types.UUID
+
         with engine.connect() as conn:
             db_names = [db[1] for db in conn.execute(text("SHOW DATABASES;")).fetchall()]
             if self.config["database"] not in db_names:

--- a/target_snowflake/connector.py
+++ b/target_snowflake/connector.py
@@ -296,7 +296,9 @@ class SnowflakeConnector(SQLConnector):
             echo=False,
         )
 
+        # Snowflake dialect doesn't natively recognise UUID columns returned by reflection
         engine.dialect.ischema_names["UUID"] = sqlalchemy.types.UUID
+        # Map Python's uuid.UUID to SQLAlchemy's UUID type when writing values
         engine.dialect.colspecs[uuid.UUID] = sqlalchemy.types.UUID
 
         with engine.connect() as conn:

--- a/target_snowflake/connector.py
+++ b/target_snowflake/connector.py
@@ -297,9 +297,9 @@ class SnowflakeConnector(SQLConnector):
         )
 
         # Snowflake dialect doesn't natively recognise UUID columns returned by reflection
-        engine.dialect.ischema_names["UUID"] = sqlalchemy.types.UUID
+        engine.dialect.ischema_names["UUID"] = sqlalchemy.types.Uuid
         # Map Python's uuid.UUID to SQLAlchemy's UUID type when writing values
-        engine.dialect.colspecs[uuid.UUID] = sqlalchemy.types.UUID
+        engine.dialect.colspecs[uuid.UUID] = sqlalchemy.types.Uuid
 
         with engine.connect() as conn:
             db_names = [db[1] for db in conn.execute(text("SHOW DATABASES;")).fetchall()]


### PR DESCRIPTION
Fixes an issue when encountering an existing column of [UUID type](https://docs.snowflake.com/en/sql-reference/data-types-uuid). The default Snowflake SQLAlchemy dialect does not seem to have any knowledge of this type, for whatever reason, although interestingly manages to create the column just fine.

```console
2026-05-01 15:42:42,973 | INFO     | target-snowflake               | target-snowflake v0.18.13.dev13+gfc73d545b, Meltano SDK v0.53.7
2026-05-01 15:42:42,973 | INFO     | target-snowflake               | Skipping parse of env var settings...
2026-05-01 15:42:42,990 | WARNING  | py.warnings                    | /home/reuben/Documents/targets/target-snowflake--meltanolabs/target_snowflake/connector.py:267: DeprecationWarning: Use base64 encoded private key instead of PEM format
  connect_args["private_key"] = self.get_private_key()

2026-05-01 15:42:42,990 | INFO     | sqlconnector                   | Private key is in PEM format
2026-05-01 15:42:43,177 | INFO     | botocore.credentials           | Found credentials in shared credentials file: ~/.aws/credentials
2026-05-01 15:42:50,827 | WARNING  | py.warnings                    | /home/reuben/Documents/targets/target-snowflake--meltanolabs/.venv/lib/python3.14/site-packages/snowflake/sqlalchemy/snowdialect.py:567: SAWarning: Did not recognize type 'UUID' of column 'id'
  sa_util.warn(

2026-05-01 15:42:50,828 | WARNING  | py.warnings                    | /home/reuben/Documents/targets/target-snowflake--meltanolabs/.venv/lib/python3.14/site-packages/snowflake/sqlalchemy/snowdialect.py:567: SAWarning: Did not recognize type 'UUID' of column 'workspaceid'
  sa_util.warn(

2026-05-01 15:42:50,991 | ERROR    | sqlconnector                   | Error adapting column type for '"REUBEN_TESTING"."TAP_MELTANO_CLOUD"."CHANNELS".id', 'NULL' to 'UUID' (new sql type)
Traceback (most recent call last):
  File "/home/reuben/Documents/targets/target-snowflake--meltanolabs/target_snowflake/connector.py", line 685, in _adapt_column_type
    super()._adapt_column_type(full_table_name, column_name, sql_type)
  File "/home/reuben/.cache/pypoetry/virtualenvs/meltanolabs-target-snowflake-mNKPeH9p-py3.10/lib/python3.10/site-packages/singer_sdk/sql/connector.py", line 1781, in _adapt_column_type
    compatible_sql_type = self.merge_sql_types([current_type, sql_type])
  File "/home/reuben/.cache/pypoetry/virtualenvs/meltanolabs-target-snowflake-mNKPeH9p-py3.10/lib/python3.10/site-packages/singer_sdk/sql/connector.py", line 1529, in merge_sql_types
    sql_types = self._sort_types(sql_types)
  File "/home/reuben/.cache/pypoetry/virtualenvs/meltanolabs-target-snowflake-mNKPeH9p-py3.10/lib/python3.10/site-packages/singer_sdk/sql/connector.py", line 1602, in _sort_types
    return sorted(sql_types, key=_get_type_sort_key, reverse=True)
  File "/home/reuben/.cache/pypoetry/virtualenvs/meltanolabs-target-snowflake-mNKPeH9p-py3.10/lib/python3.10/site-packages/singer_sdk/sql/connector.py", line 1590, in _get_type_sort_key
    pytype = sql_type.python_type
  File "/home/reuben/.cache/pypoetry/virtualenvs/meltanolabs-target-snowflake-mNKPeH9p-py3.10/lib/python3.10/site-packages/sqlalchemy/sql/type_api.py", line 649, in python_type
    raise NotImplementedError()
NotImplementedError
2026-05-01 15:32:45,070 | ERROR    | sqlconnector         | Error preparing column for '"IMPORT_RUNNER"."REUBEN"."CHANNELS".id'
Traceback (most recent call last):
  File "/home/reuben/Documents/targets/target-snowflake--meltanolabs/target_snowflake/connector.py", line 287, in prepare_column
    super().prepare_column(
  File "/home/reuben/.cache/pypoetry/virtualenvs/meltanolabs-target-snowflake-mNKPeH9p-py3.10/lib/python3.10/site-packages/singer_sdk/sql/connector.py", line 1469, in prepare_column
    self._adapt_column_type(
  File "/home/reuben/Documents/targets/target-snowflake--meltanolabs/target_snowflake/connector.py", line 685, in _adapt_column_type
    super()._adapt_column_type(full_table_name, column_name, sql_type)
  File "/home/reuben/.cache/pypoetry/virtualenvs/meltanolabs-target-snowflake-mNKPeH9p-py3.10/lib/python3.10/site-packages/singer_sdk/sql/connector.py", line 1781, in _adapt_column_type
    compatible_sql_type = self.merge_sql_types([current_type, sql_type])
  File "/home/reuben/.cache/pypoetry/virtualenvs/meltanolabs-target-snowflake-mNKPeH9p-py3.10/lib/python3.10/site-packages/singer_sdk/sql/connector.py", line 1529, in merge_sql_types
    sql_types = self._sort_types(sql_types)
  File "/home/reuben/.cache/pypoetry/virtualenvs/meltanolabs-target-snowflake-mNKPeH9p-py3.10/lib/python3.10/site-packages/singer_sdk/sql/connector.py", line 1602, in _sort_types
    return sorted(sql_types, key=_get_type_sort_key, reverse=True)
  File "/home/reuben/.cache/pypoetry/virtualenvs/meltanolabs-target-snowflake-mNKPeH9p-py3.10/lib/python3.10/site-packages/singer_sdk/sql/connector.py", line 1590, in _get_type_sort_key
    pytype = sql_type.python_type
  File "/home/reuben/.cache/pypoetry/virtualenvs/meltanolabs-target-snowflake-mNKPeH9p-py3.10/lib/python3.10/site-packages/sqlalchemy/sql/type_api.py", line 649, in python_type
    raise NotImplementedError()
NotImplementedError
```

The dialect resolves a `sqlalchemy.types.NullType` instance for the UUID column, which causes the column type adapt operation to error out due to no `python_type` implementation (hence raised `NotImplementedError`). This change resolves a `sqlachemy.types.VARCHAR` instead via registering `sqlalchemy.types.Uuid`, which can be adapted.

---

MEL-355