### PR TITLE
Bump snowflake-sqlalchemy to 1.10.0+ and drop UUID workaround

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "cryptography>=40",
     "singer-sdk[sql]~=0.53.3",
     "snowflake-connector-python[secure-local-storage]~=4.0",
-    "snowflake-sqlalchemy==1.9.0",
+    "snowflake-sqlalchemy>=1.10.0,<2",
     "sqlalchemy~=2.0.31",
 ]
 

--- a/target_snowflake/connector.py
+++ b/target_snowflake/connector.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import base64
 import binascii
 import urllib.parse
-import uuid
 from contextlib import contextmanager
 from enum import Enum
 from functools import cached_property
@@ -295,11 +294,6 @@ class SnowflakeConnector(SQLConnector):
             connect_args=self.get_connect_args(),
             echo=False,
         )
-
-        # Snowflake dialect doesn't natively recognise UUID columns returned by reflection
-        engine.dialect.ischema_names["UUID"] = sqlalchemy.types.Uuid
-        # Map Python's uuid.UUID to SQLAlchemy's UUID type when writing values
-        engine.dialect.colspecs[uuid.UUID] = sqlalchemy.types.Uuid
 
         with engine.connect() as conn:
             db_names = [db[1] for db in conn.execute(text("SHOW DATABASES;")).fetchall()]


### PR DESCRIPTION
## Description

Closes #499.

`snowflake-sqlalchemy` 1.10.0 adds native support for UUID columns — both reflection (the dialect now maps the Snowflake `UUID` type) and writes (`uuid.UUID` values bind through the dialect's `colspecs`). The workaround added in #492 to monkey-patch these mappings onto the engine's dialect is therefore no longer needed.

This PR:

- Bumps the dependency pin from `snowflake-sqlalchemy==1.9.0` to `>=1.10.0,<2`.
- Removes the two `engine.dialect.ischema_names["UUID"] = …` / `engine.dialect.colspecs[uuid.UUID] = …` lines in `target_snowflake/connector.py`.
- Drops the now-unused `import uuid`.

No other code changes — the dialect's built-in mapping covers the same cases the patch did.
