### PR TITLE
fix: Choose proper PEM vs DER format of private key instead of always using PEM format

### DIFF
--- a/target_snowflake/connector.py
+++ b/target_snowflake/connector.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from collections.abc import Generator, Iterable, Sequence
 
     import sqlalchemy as sa
+    from cryptography.hazmat.primitives.asymmetric.types import PrivateKeyTypes
     from sqlalchemy.engine import Engine
 
 
@@ -153,7 +154,7 @@ class SnowflakeConnector(SQLConnector):
 
         return sql_type
 
-    def get_private_key(self):
+    def _get_private_key(self) -> PrivateKeyTypes:
         """Get private key from the right location."""
         phrase = self.config.get("private_key_passphrase")
         encoded_passphrase = phrase.encode() if phrase else None
@@ -163,53 +164,53 @@ class SnowflakeConnector(SQLConnector):
             if not key_path.is_file():
                 error_message = f"Private key file not found: {key_path}"
                 raise FileNotFoundError(error_message)
-            with key_path.open("rb") as key_file:
-                key_content = key_file.read()
-            p_key = serialization.load_pem_private_key(
+
+            return serialization.load_pem_private_key(
+                key_path.read_bytes(),
+                password=encoded_passphrase,
+                backend=default_backend(),
+            )
+
+        private_key: str = self.config["private_key"]
+        self.logger.debug("Reading private key from config")
+        if "-----BEGIN " in private_key:
+            warn(
+                "Use base64 encoded private key instead of PEM format",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            self.logger.info("Private key is in PEM format")
+            key_content = private_key.encode()
+            return serialization.load_pem_private_key(
                 key_content,
                 password=encoded_passphrase,
                 backend=default_backend(),
             )
-        else:
-            private_key = self.config["private_key"]
-            self.logger.debug("Reading private key from config")
-            if "-----BEGIN " in private_key:
-                warn(
-                    "Use base64 encoded private key instead of PEM format",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                self.logger.info("Private key is in PEM format")
-                key_content = private_key.encode()
-                p_key = serialization.load_pem_private_key(
-                    key_content,
-                    password=encoded_passphrase,
-                    backend=default_backend(),
-                )
-            else:
-                try:
-                    self.logger.debug("Private key is in base64 format")
-                    key_content = base64.b64decode(private_key)
-                except binascii.Error as e:
-                    error_message = f"Invalid private key format: {e}"
-                    raise ValueError(error_message) from e
 
-                self.logger.debug("Attempting serialization of private key as DER")
-                try:
-                    p_key = serialization.load_der_private_key(
-                        key_content,
-                        password=encoded_passphrase,
-                        backend=default_backend(),
-                    )
-                except ValueError:
-                    self.logger.debug("DER deserialization failed; retrying as PEM")
-                    p_key = serialization.load_pem_private_key(
-                        key_content,
-                        password=encoded_passphrase,
-                        backend=default_backend(),
-                    )
+        try:
+            self.logger.debug("Private key is in base64 format")
+            key_content = base64.b64decode(private_key)
+        except binascii.Error as e:
+            error_message = f"Invalid private key format: {e}"
+            raise ValueError(error_message) from e
 
-        return p_key.private_bytes(
+        self.logger.debug("Attempting serialization of private key as DER")
+        try:
+            return serialization.load_der_private_key(
+                key_content,
+                password=encoded_passphrase,
+                backend=default_backend(),
+            )
+        except ValueError:
+            self.logger.debug("DER deserialization failed; retrying as PEM")
+            return serialization.load_pem_private_key(
+                key_content,
+                password=encoded_passphrase,
+                backend=default_backend(),
+            )
+
+    def get_private_key(self):
+        return self._get_private_key().private_bytes(
             encoding=serialization.Encoding.DER,
             format=serialization.PrivateFormat.PKCS8,
             encryption_algorithm=serialization.NoEncryption(),

--- a/target_snowflake/connector.py
+++ b/target_snowflake/connector.py
@@ -165,6 +165,11 @@ class SnowflakeConnector(SQLConnector):
                 raise FileNotFoundError(error_message)
             with key_path.open("rb") as key_file:
                 key_content = key_file.read()
+            p_key = serialization.load_pem_private_key(
+                key_content,
+                password=encoded_passphrase,
+                backend=default_backend(),
+            )
         else:
             private_key = self.config["private_key"]
             self.logger.debug("Reading private key from config")
@@ -175,7 +180,11 @@ class SnowflakeConnector(SQLConnector):
                     stacklevel=2,
                 )
                 self.logger.info("Private key is in PEM format")
-                key_content = private_key.encode()
+                p_key = serialization.load_pem_private_key(
+                    private_key.encode(),
+                    password=encoded_passphrase,
+                    backend=default_backend(),
+                )
             else:
                 try:
                     self.logger.debug("Private key is in base64 format")
@@ -183,11 +192,11 @@ class SnowflakeConnector(SQLConnector):
                 except binascii.Error as e:
                     error_message = f"Invalid private key format: {e}"
                     raise ValueError(error_message) from e
-        p_key = serialization.load_pem_private_key(
-            key_content,
-            password=encoded_passphrase,
-            backend=default_backend(),
-        )
+                p_key = serialization.load_der_private_key(
+                    key_content,
+                    password=encoded_passphrase,
+                    backend=default_backend(),
+                )
 
         return p_key.private_bytes(
             encoding=serialization.Encoding.DER,

--- a/target_snowflake/connector.py
+++ b/target_snowflake/connector.py
@@ -180,8 +180,9 @@ class SnowflakeConnector(SQLConnector):
                     stacklevel=2,
                 )
                 self.logger.info("Private key is in PEM format")
+                key_content = private_key.encode()
                 p_key = serialization.load_pem_private_key(
-                    private_key.encode(),
+                    key_content,
                     password=encoded_passphrase,
                     backend=default_backend(),
                 )
@@ -191,7 +192,8 @@ class SnowflakeConnector(SQLConnector):
                     self.logger.debug("Private key is in base64 format")
                     key_content = base64.b64decode(private_key)
                 except binascii.Error as e:
-                    raise ValueError(f"Invalid private key format: {e}") from e
+                    error_message = f"Invalid private key format: {e}"
+                    raise ValueError(error_message) from e
 
                 # Try DER first; fall back to PEM for backward compatibility.
                 self.logger.debug("Attempting serialization of private key as DER")
@@ -202,7 +204,7 @@ class SnowflakeConnector(SQLConnector):
                         backend=default_backend(),
                     )
                 except ValueError:
-                    self.logger.debug("DER deserialization failed; retrying as PEM")
+                    self.logger.info("DER deserialization failed; retrying as PEM")
                     p_key = serialization.load_pem_private_key(
                         key_content,
                         password=encoded_passphrase,

--- a/target_snowflake/connector.py
+++ b/target_snowflake/connector.py
@@ -186,17 +186,28 @@ class SnowflakeConnector(SQLConnector):
                     backend=default_backend(),
                 )
             else:
+                # Decode the base64-encoded private key bytes.
                 try:
                     self.logger.debug("Private key is in base64 format")
                     key_content = base64.b64decode(private_key)
                 except binascii.Error as e:
-                    error_message = f"Invalid private key format: {e}"
-                    raise ValueError(error_message) from e
-                p_key = serialization.load_der_private_key(
-                    key_content,
-                    password=encoded_passphrase,
-                    backend=default_backend(),
-                )
+                    raise ValueError(f"Invalid private key format: {e}") from e
+
+                # Try DER first; fall back to PEM for backward compatibility.
+                self.logger.debug("Attempting serialization of private key as DER")
+                try:
+                    p_key = serialization.load_der_private_key(
+                        key_content,
+                        password=encoded_passphrase,
+                        backend=default_backend(),
+                    )
+                except ValueError:
+                    self.logger.debug("DER deserialization failed; retrying as PEM")
+                    p_key = serialization.load_pem_private_key(
+                        key_content,
+                        password=encoded_passphrase,
+                        backend=default_backend(),
+                    )
 
         return p_key.private_bytes(
             encoding=serialization.Encoding.DER,

--- a/target_snowflake/connector.py
+++ b/target_snowflake/connector.py
@@ -154,10 +154,8 @@ class SnowflakeConnector(SQLConnector):
 
         return sql_type
 
-    def _get_private_key(self) -> PrivateKeyTypes:
+    def _get_private_key_content(self) -> bytes:
         """Get private key from the right location."""
-        phrase = self.config.get("private_key_passphrase")
-        encoded_passphrase = phrase.encode() if phrase else None
         if "private_key_path" in self.config:
             self.logger.debug("Reading private key from file: %s", self.config["private_key_path"])
             key_path = Path(self.config["private_key_path"])
@@ -165,11 +163,7 @@ class SnowflakeConnector(SQLConnector):
                 error_message = f"Private key file not found: {key_path}"
                 raise FileNotFoundError(error_message)
 
-            return serialization.load_pem_private_key(
-                key_path.read_bytes(),
-                password=encoded_passphrase,
-                backend=default_backend(),
-            )
+            return key_path.read_bytes()
 
         private_key: str = self.config["private_key"]
         self.logger.debug("Reading private key from config")
@@ -180,12 +174,7 @@ class SnowflakeConnector(SQLConnector):
                 stacklevel=2,
             )
             self.logger.info("Private key is in PEM format")
-            key_content = private_key.encode()
-            return serialization.load_pem_private_key(
-                key_content,
-                password=encoded_passphrase,
-                backend=default_backend(),
-            )
+            return private_key.encode()
 
         try:
             self.logger.debug("Private key is in base64 format")
@@ -194,7 +183,13 @@ class SnowflakeConnector(SQLConnector):
             error_message = f"Invalid private key format: {e}"
             raise ValueError(error_message) from e
 
-        self.logger.debug("Attempting serialization of private key as DER")
+        return key_content
+
+    def _load_private_key(self) -> PrivateKeyTypes:
+        phrase = self.config.get("private_key_passphrase")
+        encoded_passphrase = phrase.encode() if phrase else None
+        key_content = self._get_private_key_content()
+
         try:
             return serialization.load_der_private_key(
                 key_content,
@@ -210,7 +205,7 @@ class SnowflakeConnector(SQLConnector):
             )
 
     def get_private_key(self):
-        return self._get_private_key().private_bytes(
+        return self._load_private_key().private_bytes(
             encoding=serialization.Encoding.DER,
             format=serialization.PrivateFormat.PKCS8,
             encryption_algorithm=serialization.NoEncryption(),

--- a/target_snowflake/connector.py
+++ b/target_snowflake/connector.py
@@ -187,7 +187,6 @@ class SnowflakeConnector(SQLConnector):
                     backend=default_backend(),
                 )
             else:
-                # Decode the base64-encoded private key bytes.
                 try:
                     self.logger.debug("Private key is in base64 format")
                     key_content = base64.b64decode(private_key)
@@ -195,7 +194,6 @@ class SnowflakeConnector(SQLConnector):
                     error_message = f"Invalid private key format: {e}"
                     raise ValueError(error_message) from e
 
-                # Try DER first; fall back to PEM for backward compatibility.
                 self.logger.debug("Attempting serialization of private key as DER")
                 try:
                     p_key = serialization.load_der_private_key(
@@ -204,7 +202,7 @@ class SnowflakeConnector(SQLConnector):
                         backend=default_backend(),
                     )
                 except ValueError:
-                    self.logger.info("DER deserialization failed; retrying as PEM")
+                    self.logger.debug("DER deserialization failed; retrying as PEM")
                     p_key = serialization.load_pem_private_key(
                         key_content,
                         password=encoded_passphrase,


### PR DESCRIPTION
Closes #427.

# Issue
Right now when I try to run a `meltano run` command with my private key in a PEM format, i get the warning:

<img width="1546" height="950" alt="PEMFormat_Meltano" src="https://github.com/user-attachments/assets/118a0196-b2f0-4b8b-a7fe-4aec28853600" />

However, when i remove the first and last line (BEGIN/END) for the formatting and put it all one one line, I get an error which ends in a stacktrace as such

```
line='            self.connector.prepare_schema(\n'), TracebackFrame(filename='C:\\Git\\elt-pipeline\\.meltano\\loaders\\target-snowflake\\venv\\Lib\\site-packages\\singer_sdk\\sql\\connector.py', function='prepare_schema', lineno=1378, line='        if not self.schema_exists(schema_name):\n'), TracebackFrame(filename='C:\\Git\\elt-pipeline\\.meltano\\loaders\\target-snowflake\\venv\\Lib\\site-packages\\target_snowflake\\connector.py', function='schema_exists', lineno=393, line='        schema_names = self.inspector.get_schema_names()\n'), TracebackFrame(filename='C:\\Git\\elt-pipeline\\.meltano\\loaders\\target-snowflake\\venv\\Lib\\site-packages\\target_snowflake\\connector.py', function='inspector', lineno=121, line='            self._inspector = sqlalchemy.inspect(self._engine)\n'), TracebackFrame(filename='C:\\Git\\elt-pipeline\\.meltano\\loaders\\target-snowflake\\venv\\Lib\\site-packages\\singer_sdk\\sql\\connector.py', function='_engine', lineno=879, line='            self._cached_engine = self.create_engine()\n'), TracebackFrame(filename='C:\\Git\\elt-pipeline\\.meltano\\loaders\\target-snowflake\\venv\\Lib\\site-packages\\target_snowflake\\connector.py', function='create_engine', lineno=294, line='            connect_args=self.get_connect_args(),\n'), TracebackFrame(filename='C:\\Git\\elt-pipeline\\.meltano\\loaders\\target-snowflake\\venv\\Lib\\site-packages\\target_snowflake\\connector.py', function='get_connect_args', lineno=267, line='            connect_args["private_key"] = self.get_private_key()\n'), TracebackFrame(filename='C:\\Git\\elt-pipeline\\.meltano\\loaders\\target-snowflake\\venv\\Lib\\site-packages\\target_snowflake\\connector.py', function='get_private_key', lineno=202, line='        p_key = serialization.load_pem_private_key(\n')], cause=None, context=None), 'name': 'target-snowflake', 'pid': 31272, 'thread_name': 'MainThread', 'app_name': 'singer-sdk', 'stream_name': None, 'plugin_logger': 'target-snowflake', 'event': 'Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming', 'run_id': '019effb9-34dd-7b22-9916-1e25eea2f5cf', 'level': 'error', 'timestamp': '2026-06-25T17:00:20.104056Z'}
  Arguments: ()
  2026-06-25T17:00:20.397811Z [error    ] meltano      Loader failed      
  2026-06-25T17:00:20.398595Z [error    ] meltano      Block run completed
  2026-06-25T17:00:20.398897Z [info     ] meltano      Run completed  
```

I then tried to encode it as a base64 var, taking my private key, processing it via
```
import base64

encoded = base64.b64encode(open("private_key.pem", "rb").read()).decode()
print(encoded)
```
then importing that output into my env var.

Funnily enough, that then worked for meltano's normal tap/target, but broke the dbt-snowflake connection

```
2026-06-25T17:38:05.194254Z [info     ] meltano      17:38:05  Found 288 models, 5545 data tests, 104 seeds, 2 operations, 327 sources, 939 macros
  2026-06-25T17:38:05.277444Z [info     ] meltano      17:38:05           
  2026-06-25T17:38:05.277843Z [info     ] meltano      17:38:05  Concurrency: 8 threads (target='dev')
  2026-06-25T17:38:05.278073Z [info     ] meltano      17:38:05           
  2026-06-25T17:38:05.355483Z [info     ] meltano      17:38:05           
  2026-06-25T17:38:05.355853Z [info     ] meltano      17:38:05  Finished running  in 0 hours 0 minutes and 0.08 seconds (0.08s).
  2026-06-25T17:38:05.356165Z [info     ] meltano      17:38:05  Encountered an error:
  2026-06-25T17:38:05.356340Z [info     ] meltano      Runtime Error      
  2026-06-25T17:38:05.356505Z [info     ] meltano        Database error while listing schemas in database "TECH01"
  2026-06-25T17:38:05.356785Z [info     ] meltano        Database Error   
  2026-06-25T17:38:05.356956Z [info     ] meltano          Could not deserialize key data. The data may be in an incorrect format, it may be encrypted with an unsupported algorithm, or it may be an unsupported key type (e.g. EC curves with explicit parameters). Details: ASN.1 parsing error: unexpected tag (got Tag { value: 13, constructed: true, class: Universal })
  2026-06-25T17:38:06.736057Z [info     ] meltano      error invoking dbt None        error_message=dbt invocation failed returncode=2
```

The only solution at this juncture was to have it as two separate env vars since the dbt-snowflake didn't like the b64 encoding. Which I thought was kind of silly.

# What I changed
I then looked into the connector.py and noticed that in all 3 sections of the python function `get_private_key` that no matter what it was always serializing it as if it was a PEM format. So instead now it treats it as a DER format in the final `else` condition at first, before falling back to PEM. The other two conditions that are checked beforehand still rely on PEM.

For now the deprecation warnings are in place in case the maintainer decides to go forward with it, but at least now we can put the private key on a single line as an env var and continue to read it in either full PEM format, removing the headers and leaving it as one big block, or b64 encoding the whole PEM file (though in that case it would still break with dbt).

# Solution Review
I did the changes locally on my repo (where i went directly into the connector.py)
<img width="1499" height="992" alt="image" src="https://github.com/user-attachments/assets/b86a2d2c-c587-4f01-816e-86840120b02e" />

Then i ran one of my tap/target commands, 
`meltano run tap-mssql-static target-snowflake`
followed by a dbt command.
`meltano invoke dbt-snowflake:run --select stg_core_db__program`

## Normal PEM Format

<img width="1546" height="950" alt="PEMFormat_Meltano" src="https://github.com/user-attachments/assets/b63b8001-6046-4cc3-aca3-9da296b8aa66" />
<img width="1621" height="874" alt="PEMFormat_DBT" src="https://github.com/user-attachments/assets/d36fb468-6de8-45c3-9407-d1734b0d7a25" />

## Removed the PEM, Left as One Line
<img width="2106" height="896" alt="NonPEMFormat_Meltano" src="https://github.com/user-attachments/assets/489adc48-3010-41f3-8b25-fef131ebdd2d" />
<img width="1502" height="729" alt="NonPEMFormat_DBT" src="https://github.com/user-attachments/assets/890b5942-6a07-4542-991c-78cfe71b4b14" />

## Converted the PEM into a full b64
Showing again that it works for meltano, but breaks for dbt (which it is its own separate issue).
<img width="929" height="143" alt="image" src="https://github.com/user-attachments/assets/97100f50-5af5-48c8-abc7-fb39de68b029" />

<img width="929" height="109" alt="image" src="https://github.com/user-attachments/assets/20567295-dd95-42f3-968f-14c21d88ce72" />


## Forced the PEM b64 into a bad value
I removed 4 characters from the PEM data I converted into b64, to see if it would error out properly, and it did.
<img width="994" height="500" alt="image" src="https://github.com/user-attachments/assets/9455371e-36fb-429c-a4cf-9ac589267529" />



