### PR TITLE
fix: Report accurate row counts from MERGE and COPY INTO

### DIFF
--- a/target_snowflake/connector.py
+++ b/target_snowflake/connector.py
@@ -596,7 +596,13 @@ class SnowflakeConnector(SQLConnector):
             )
             self.logger.debug("Merging with SQL: %s", merge_statement)
             result = conn.execute(merge_statement, **kwargs)
-            return result.rowcount
+            # MERGE's rowcount, like COPY INTO's below, isn't reliable via the generic
+            # DBAPI/SQLAlchemy rowcount attribute - Snowflake's MERGE instead returns a
+            # single-row result set: ("number of rows inserted", "number of rows updated",
+            # "number of rows deleted"). Sum those instead of trusting result.rowcount,
+            # which silently undercounts.
+            row = result.fetchone()
+            return sum(row) if row is not None else result.rowcount
 
     def copy_from_stage(
         self,
@@ -622,7 +628,10 @@ class SnowflakeConnector(SQLConnector):
             )
             self.logger.debug("Copying with SQL: %s", copy_statement)
             result = conn.execute(copy_statement, **kwargs)
-            return result.rowcount
+            # COPY INTO rowcount = number of files, not rows.
+            # Fetch the result set and sum the rows_loaded column instead.
+            rows = result.fetchall()
+            return sum(r[3] for r in rows) if rows else result.rowcount
 
     def drop_file_format(self, file_format: str) -> None:
         """Drop a file format in the schema.


### PR DESCRIPTION
## Summary
- Snowflake's `MERGE` returns a single-row result set of `(inserted, updated, deleted)` counts; summing those replaces the generic `result.rowcount`, which silently undercounts for MERGE statements.
- Snowflake's `COPY INTO` result set's `rowcount` reflects the number of files processed, not rows loaded; sum the `rows_loaded` column from the result set instead.
- Ported from a downstream fix in the [Matatika fork](https://github.com/Matatika/target-snowflake--meltanolabs) of this target, adapted to this repo's current connector implementation.

## Test plan
- [x] `ruff check` passes
- [x] `mypy` passes
- [x] Unit test suite passes (`tests/test_connector.py`, `tests/test_oauth_unit.py`)
- [ ] Integration tests against a live Snowflake account (not run here — no credentials in this environment)