### PR TITLE
fix: Invalidate cached table/inspector state after DDL

### DIFF
--- a/target_snowflake/connector.py
+++ b/target_snowflake/connector.py
@@ -112,6 +112,21 @@ class SnowflakeConnector(SQLConnector):
             self._inspector = sqlalchemy.inspect(self._engine)
         return self._inspector
 
+    def invalidate_table_cache(self, full_table_name: str | FullyQualifiedName) -> None:
+        """Discard cached reflection state for a table after DDL.
+
+        Dropping the `table_cache` entry alone is not enough. The Inspector
+        memoises reflection for its lifetime, and snowflake-sqlalchemy caches
+        columns per *schema*, so a table created after the first reflection of
+        that schema stays invisible and reflecting it raises NoSuchTableError.
+        The Inspector is dropped so the next reflection queries Snowflake.
+
+        Args:
+            full_table_name: the table whose cached state is now stale.
+        """
+        self.table_cache.pop(full_table_name, None)
+        self._inspector = None
+
     def get_table_columns(
         self,
         full_table_name: str | FullyQualifiedName,

--- a/target_snowflake/sinks.py
+++ b/target_snowflake/sinks.py
@@ -79,6 +79,9 @@ class SnowflakeSink(SQLSink[SnowflakeConnector]):
             self.connector.prepare_schema(
                 self.conform_name(self.schema_name, object_type="schema"),
             )
+
+        self.connector.invalidate_table_cache(self.full_table_name)
+
         try:
             self.connector.prepare_table(
                 full_table_name=self.full_table_name,
@@ -89,6 +92,8 @@ class SnowflakeSink(SQLSink[SnowflakeConnector]):
         except Exception:
             self.logger.exception("Error creating %s %s", self.full_table_name, self.conform_schema(self.schema))
             raise
+
+        self.connector.invalidate_table_cache(self.full_table_name)
 
     def conform_name(
         self,

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import pytest
 import snowflake.sqlalchemy.custom_types as sct
+import sqlalchemy
 from sqlalchemy import types
 
 from target_snowflake.connector import SnowflakeConnector, SnowflakeTimestampType
@@ -179,3 +180,23 @@ def test_format_identifier(
 ):
     connectable_connector.config.update(config)
     assert connectable_connector.format_identifier(identifier) == expected_formatted
+
+
+def test_invalidate_table_cache_drops_entry_and_resets_inspector(connector: SnowflakeConnector):
+    connector.table_cache["db.schema.table"] = {"col": object()}
+    connector._inspector = mock.Mock(spec=sqlalchemy.Inspector)  # noqa: SLF001
+
+    connector.invalidate_table_cache("db.schema.table")
+
+    assert "db.schema.table" not in connector.table_cache
+    assert connector._inspector is None  # noqa: SLF001
+
+
+def test_invalidate_table_cache_leaves_other_tables_cached(connector: SnowflakeConnector):
+    connector.table_cache["db.schema.users"] = {"id": object()}
+    connector.table_cache["db.schema.posts"] = {"id": object()}
+
+    connector.invalidate_table_cache("db.schema.users")
+
+    assert "db.schema.users" not in connector.table_cache
+    assert "db.schema.posts" in connector.table_cache


### PR DESCRIPTION
## Summary
- `SnowflakeConnector.get_table_columns()` caches reflected columns per full table name (`table_cache`), and the SQLAlchemy `Inspector` separately memoises reflection results for its own lifetime (`_inspector`).
- Once a schema has been reflected, creating a new table (or altering an existing one) within that schema left both caches stale — a newly created table could raise `NoSuchTableError` the next time its columns were looked up later in the same sync run, since the cached `Inspector` never re-queries Snowflake for tables it hasn't seen before.
- Adds `invalidate_table_cache()` to `SnowflakeConnector`, dropping the `table_cache` entry and resetting `_inspector` to `None` so the next reflection re-queries Snowflake.
- Calls it in `SnowflakeSink.setup()` both before and after `prepare_table()`: before, in case an earlier sink already reflected this schema and cached a stale (or absent) view of this table; after, so `prepare_table()`'s own DDL doesn't leave the cache stale for the rest of the sync.
- Ported from a downstream fix in the [Matatika fork](https://github.com/Matatika/target-snowflake--meltanolabs) of this target.

## Test plan
- [x] `ruff check` passes
- [x] `mypy` passes
- [x] Unit test suite passes, including two new tests covering `invalidate_table_cache` (drops the entry + resets the inspector; leaves other cached tables untouched)
- [ ] Integration tests against a live Snowflake account (not run here — no credentials in this environment; this is exactly the kind of change that's hard to catch without a real account, since it only manifests when a table is created and then immediately reflected again within the same sync)