### PR TITLE
feat: add use_raw_stream_names config to control table naming

### DIFF
--- a/target_snowflake/sinks.py
+++ b/target_snowflake/sinks.py
@@ -66,6 +66,9 @@ class SnowflakeSink(SQLSink[SnowflakeConnector]):
 
     @property
     def table_name(self) -> str:
+        if self.config.get("use_raw_stream_names", True):
+            return self.conform_name(self.stream_name, "table").upper()
+
         return super().table_name.upper()
 
     def setup(self) -> None:

--- a/target_snowflake/sinks.py
+++ b/target_snowflake/sinks.py
@@ -66,7 +66,7 @@ class SnowflakeSink(SQLSink[SnowflakeConnector]):
 
     @property
     def table_name(self) -> str:
-        if self.config.get("use_raw_stream_names", True):
+        if self.config.get("use_raw_stream_names", False):
             return self.conform_name(self.stream_name, "table").upper()
 
         return super().table_name.upper()

--- a/target_snowflake/target.py
+++ b/target_snowflake/target.py
@@ -145,7 +145,7 @@ class TargetSnowflake(SQLTarget):
         th.Property(
             "use_raw_stream_names",
             th.BooleanType,
-            default=True,
+            default=False,
             description=(
                 "Whether to use raw stream names as table names instead of informal Singer convention as last "
                 "hyphen-separated part of stream name."

--- a/target_snowflake/target.py
+++ b/target_snowflake/target.py
@@ -142,6 +142,15 @@ class TargetSnowflake(SQLTarget):
             default=False,
             description="Whether to normalise identifiers into snake_case.",
         ),
+        th.Property(
+            "use_raw_stream_names",
+            th.BooleanType,
+            default=True,
+            description=(
+                "Whether to use raw stream names as table names instead of informal Singer convention as last "
+                "hyphen-separated part of stream name."
+            ),
+        ),
     ).to_dict()
 
     default_sink_class = SnowflakeSink


### PR DESCRIPTION
## Summary
- The SDK's default `table_name` derivation splits the stream name on `"-"` and uses only the last segment — an informal Singer convention for `<schema>-<table>`-style stream names. This silently truncates any stream name that happens to contain a hyphen for an unrelated reason (e.g. a raw source object name like `Some-Legacy-Object`), producing a table named just `Object` instead of the full name.
- Adds `use_raw_stream_names` config (default `False`, matching the SDK's existing behavior): when set to `True`, the table is named after the full, conformed stream name instead.
- Ported from a downstream fix in the [Matatika fork](https://github.com/Matatika/target-snowflake--meltanolabs) of this target.

## Default: `False`
Initially landed with a default of `True`, but confirmed with the Matatika Meltano catalog plugin definition (`target-snowflake--matatika.yml`) that it already pins `use_raw_stream_names: true` explicitly via a catalog YAML override. So there's no need for this repo's own default to change existing table-naming behavior for anyone who hasn't opted in — defaulting to `False` keeps this a purely additive, backward-compatible config option, and downstream consumers like Matatika's catalog continue to get the raw-name behavior via their own explicit override.

## Test plan
- [x] `ruff check` passes
- [x] `mypy` passes
- [x] Unit test suite passes
- [ ] Integration tests against a live Snowflake account (not run here — no credentials in this environment)

https://claude.ai/code/session_01LnU2uNtQ9HCsLjrKw5Krmu