### PR TITLE
feat: Add `load_method` config for upsert/overwrite loading

### DIFF
--- a/target_snowflake/connector.py
+++ b/target_snowflake/connector.py
@@ -650,6 +650,15 @@ class SnowflakeConnector(SQLConnector):
             rows = result.fetchall()
             return sum(r[3] for r in rows) if rows else result.rowcount
 
+    def truncate_table(self, full_table_name: str | FullyQualifiedName) -> None:
+        """Truncate a table.
+
+        Args:
+            full_table_name: The fully-qualified name of the table to truncate.
+        """
+        with self._connect() as conn, conn.begin():
+            conn.execute(text(f"truncate table {full_table_name}"))
+
     def drop_file_format(self, file_format: str) -> None:
         """Drop a file format in the schema.
 

--- a/target_snowflake/sinks.py
+++ b/target_snowflake/sinks.py
@@ -99,6 +99,10 @@ class SnowflakeSink(SQLSink[SnowflakeConnector]):
 
         self.connector.invalidate_table_cache(self.full_table_name)
 
+        if self.config.get("load_method", "upsert") == "overwrite":
+            self.logger.info("load_method=overwrite: truncating %s", self.full_table_name)
+            self.connector.truncate_table(self.full_table_name)
+
     def _get_file_format_name(self, file_type: str) -> str:
         """Get (creating on first use) the file format name for a given file type.
 
@@ -228,7 +232,7 @@ class SnowflakeSink(SQLSink[SnowflakeConnector]):
         sync_id = f"{self.stream_name}-{uuid4()}"
         try:
             self.connector.put_batches_to_stage(sync_id=sync_id, files=files)
-            if self.key_properties:
+            if self.key_properties and self.config.get("load_method", "upsert") == "upsert":
                 # merge into destination table
                 record_count = self.connector.merge_from_stage(
                     full_table_name=full_table_name,

--- a/target_snowflake/target.py
+++ b/target_snowflake/target.py
@@ -151,6 +151,19 @@ class TargetSnowflake(SQLTarget):
                 "hyphen-separated part of stream name."
             ),
         ),
+        th.Property(
+            "load_method",
+            th.StringType,
+            allowed_values=["upsert", "overwrite"],
+            default="upsert",
+            description=(
+                "Controls how records are written to the destination table. "
+                "'upsert' (default) uses MERGE INTO, matching on key properties to update "
+                "existing rows and insert new ones. "
+                "'overwrite' truncates the table then uses COPY INTO, replacing all existing "
+                "rows — faster for initial loads but destructive if run on a populated table."
+            ),
+        ),
     ).to_dict()
 
     default_sink_class = SnowflakeSink


### PR DESCRIPTION
## Summary
- The target always used `MERGE INTO` when a stream had key properties, even for a one-shot full-table-replace load where the extra latching logic (and Snowflake's dedup-by-key `QUALIFY`) is unnecessary overhead and the caller really just wants a full refresh.
- Adds `load_method` config (default `"upsert"`, matching existing behavior — this is a purely additive, backward-compatible option):
  - `"upsert"` keeps the current `MERGE INTO`/`COPY INTO`-append behavior.
  - `"overwrite"` truncates the table once in `setup()`, before any batches are processed, then always uses `COPY INTO` (append) for every batch regardless of key properties, since the table is guaranteed empty at the start of the sync.
- Adds `SnowflakeConnector.truncate_table()`.
- Ported from a downstream fix in the [Matatika fork](https://github.com/Matatika/target-snowflake--meltanolabs) of this target.

## Test plan
- [x] `ruff check` passes
- [x] `mypy` passes
- [x] Unit test suite passes
- [ ] Integration tests against a live Snowflake account (not run here — no credentials in this environment; worth a manual sync with `load_method: overwrite` against a pre-populated table to confirm the truncate+append path)