### PR TITLE
feat: New `uuid_format` setting to toggle between mapping strings with `format: uuid` either as native Snowflake `UUID` or `STRING(36)` columns

### DIFF
--- a/target_snowflake/connector.py
+++ b/target_snowflake/connector.py
@@ -415,6 +415,9 @@ class SnowflakeConnector(SQLConnector):
             "date-time",
             TIMESTAMP_TYPES[self.config.get("timestamp_type", DEFAULT_TIMESTAMP_TYPE)],
         )
+        if self.config.get("uuid_format", "native") == "string":
+            # a standard UUID string is 36 characters long
+            to_sql.register_format_handler("uuid", lambda _: sct.STRING(36))
         return to_sql
 
     def schema_exists(self, schema_name: str) -> bool:

--- a/target_snowflake/target.py
+++ b/target_snowflake/target.py
@@ -131,6 +131,18 @@ class TargetSnowflake(SQLTarget):
             description="Snowflake timestamp type to use for date-time properties.",
         ),
         th.Property(
+            "uuid_format",
+            th.StringType,
+            allowed_values=["native", "string"],
+            default="native",
+            description=(
+                "Snowflake column type/value format for `format: uuid` string properties. "
+                "'native' (default) uses SQLAlchemy's native UUID type, which compiles to CHAR(32) on Snowflake "
+                "and strips dashes from the value. "
+                "'string' uses a STRING(36) column and writes the value as-is, preserving dashes."
+            ),
+        ),
+        th.Property(
             "quoted_identifiers_ignore_case",
             th.BooleanType,
             default=True,

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -84,6 +84,18 @@ def test_datetime_to_sql(connector: SnowflakeConnector, config: dict, expected_t
     assert isinstance(sql_type, expected_type)
 
 
+def test_uuid_to_sql_defaults_to_native(connector: SnowflakeConnector):
+    sql_type = connector.to_sql_type({"type": "string", "format": "uuid"})
+    assert isinstance(sql_type, types.UUID)
+
+
+def test_uuid_to_sql_as_string(connector: SnowflakeConnector):
+    connector.config.update({"uuid_format": "string"})
+    sql_type = connector.to_sql_type({"type": "string", "format": "uuid"})
+    assert isinstance(sql_type, sct.STRING)
+    assert sql_type.length == 36
+
+
 def test_to_sql_type_with_max_varchar_length(connector: SnowflakeConnector):
     sql_type = connector.to_sql_type({"type": "string", "maxLength": 1_000_000})
     assert isinstance(sql_type, types.VARCHAR)


### PR DESCRIPTION
Related:

- https://github.com/Matatika/target-snowflake--meltanolabs/pull/15

Defaults to `uuid_format: native` for backwards-compatibility. 

