### PR TITLE
fix: Avoid re-adding existing columns whose names require quoting

### DIFF
--- a/target_snowflake/connector.py
+++ b/target_snowflake/connector.py
@@ -825,8 +825,15 @@ class SnowflakeConnector(SQLConnector):
 
             formatted = formatted.lower()
 
-            # Reserved words are returned as they exist/would be created as in Snowflake
-            if formatted in self.formatter.reserved_words:
+            # ...but only when SQLAlchemy actually hands the name back lowercased.
+            #
+            # `SnowflakeDialect.normalize_name` lowercases a stored (upper-case) identifier
+            # only if the lower-case form needs no quoting. Anything that *does* require
+            # quoting - reserved words such as `user`, and names containing spaces, colons,
+            # brackets, etc. - is returned exactly as Snowflake stored it, which under
+            # QUOTED_IDENTIFIERS_IGNORE_CASE is upper case. Those must be compared in upper
+            # case or an existing column looks missing and gets re-added via ALTER TABLE.
+            if '"' in self.formatter.format_collation(formatted):
                 formatted = formatted.upper()
                 safe_formatted = safe_formatted.upper()
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -194,6 +194,86 @@ def test_format_identifier(
     assert connectable_connector.format_identifier(identifier) == expected_formatted
 
 
+@pytest.mark.parametrize(
+    "column_name",
+    [
+        pytest.param("Order Total [USD]", id="spaces_brackets_mixed_case"),
+        pytest.param("customer:id", id="colon"),
+        pytest.param("field with spaces", id="spaces"),
+        pytest.param("Nested[0]", id="brackets"),
+        pytest.param("ns:Attribute [meta]", id="colon_spaces_brackets"),
+        pytest.param("hyphenated-column", id="hypthenated"),
+        pytest.param("user", id="reserved_word"),
+    ],
+)
+@pytest.mark.usefixtures("mock_engine_connect")
+def test_prepare_column_matches_existing_quoted_column(
+    connectable_connector: SnowflakeConnector,
+    column_name: str,
+):
+    # Columns needing quoting must not be re-added when they already exist.
+    connectable_connector.config.update(
+        {"quoted_identifiers_ignore_case": True, "normalise_casing": False},
+    )
+
+    # The name Snowflake reports for a column originally created as a quoted identifier.
+    stored_name = column_name.upper()
+    existing_columns = {stored_name: sqlalchemy.Column(stored_name, types.VARCHAR())}
+
+    with (
+        mock.patch.object(connectable_connector, "get_table_columns", return_value=existing_columns),
+        mock.patch.object(connectable_connector, "_create_empty_column") as create_column,
+        mock.patch.object(connectable_connector, "_adapt_column_type") as adapt_column,
+    ):
+        connectable_connector.prepare_column(
+            "TEST_DATABASE.TEST_SCHEMA.TEST_TABLE",
+            column_name,
+            types.VARCHAR(),
+        )
+
+    create_column.assert_not_called()
+    adapt_column.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("column_name", "reported_name"),
+    [
+        pytest.param("plain_column", "plain_column", id="plain"),
+        pytest.param("MixedCase", "mixedcase", id="mixed_case"),
+        pytest.param("emailAddress", "emailaddress", id="camel_case"),
+        pytest.param("EMAIL_ADDRESS", "email_address", id="upper_case"),
+    ],
+)
+@pytest.mark.usefixtures("mock_engine_connect")
+def test_prepare_column_matches_existing_unquoted_column(
+    connectable_connector: SnowflakeConnector,
+    column_name: str,
+    reported_name: str,
+):
+    # Guards the quoted-identifier fix against over-correcting. Snowflake stores these
+    # upper case too, but because the lower-case form needs no quoting `normalize_name`
+    # hands them back lowercased, so they must still be compared in lower case.
+    connectable_connector.config.update(
+        {"quoted_identifiers_ignore_case": True, "normalise_casing": False},
+    )
+
+    existing_columns = {reported_name: sqlalchemy.Column(reported_name, types.VARCHAR())}
+
+    with (
+        mock.patch.object(connectable_connector, "get_table_columns", return_value=existing_columns),
+        mock.patch.object(connectable_connector, "_create_empty_column") as create_column,
+        mock.patch.object(connectable_connector, "_adapt_column_type") as adapt_column,
+    ):
+        connectable_connector.prepare_column(
+            "TEST_DATABASE.TEST_SCHEMA.TEST_TABLE",
+            column_name,
+            types.VARCHAR(),
+        )
+
+    create_column.assert_not_called()
+    adapt_column.assert_called_once()
+
+
 def test_invalidate_table_cache_drops_entry_and_resets_inspector(connector: SnowflakeConnector):
     connector.table_cache["db.schema.table"] = {"col": object()}
     connector._inspector = mock.Mock(spec=sqlalchemy.Inspector)  # noqa: SLF001


### PR DESCRIPTION
This should fix a regression from #518. I got multiple failures on my overnight pipelines looking like this:

```
2026-09-01T08:00:06.148148Z [info     ] target-snowflake sqlalchemy.exc.ProgrammingError: (snowflake.connector.errors.ProgrammingError) 001430 (42601): SQL compilation error:
2026-09-01T08:00:06.148213Z [info     ] target-snowflake column 'AMAZON-ORDER-ID' already exists
2026-09-01T08:00:06.148300Z [info     ] target-snowflake [SQL: ALTER TABLE "RAW"."AMAZON_SP"."AMAZONSP_FULFILLED_SHIPMENTS_REPORT" ADD COLUMN "amazon-order-id" VARCHAR]
```

My fault being pinned to main. This error happened for several taps for columns with hyphens, colons, and spaces.

Snowflake stores every identifier upper-case, and SQLAlchemy's `normalize_name` only lower-cases it back when the lower-case form doesn't need quoting. Names that do need quoting because of special characters or reserved words come back upper-case. `format_identifier` lower-cased them anyway, so `column_exists` never matched and `ALTER TABLE` fired for columns that already exist.